### PR TITLE
fix: use global sdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('VisionCameraCodeScanner_compileSdkVersion', 30)
+    compileSdkVersion safeExtGet('compileSdkVersion', 30)
     ndkVersion "21.4.7075529"
     defaultConfig {
-        minSdkVersion safeExtGet('VisionCameraCodeScanner_minSdkVersion', 21)
-        targetSdkVersion safeExtGet('VisionCameraCodeScanner_targetSdkVersion', 31)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 31)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Hello !
With react-native 0.70, many users will met builds problems with mismatch versions between their project (31) and this library (30).

With this PR, gradle build the library with global `compileSdkVersion` `minSdkVersion` and `targetSdkVersion` versions, defined in your project `android/build.graddle`. This way, this library versions evolve with the react-native ones

This should fix #92 #90 