### PR TITLE
Use Types from src/index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "VisionCamera Frame Processor Plugin to read barcodes using MLKit Vision Barcode Scanning",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "src/index.ts",
   "react-native": "src/index.ts",
   "source": "src/index.ts",
   "files": [


### PR DESCRIPTION
My vscode is complaining about types.
```
Cannot find module 'vision-camera-code-scanner' or its corresponding type declarations.ts(2307)
```