### PR TITLE
update version of react-native-vision-camera

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "react-native": "0.66.3",
     "react-native-reanimated": "2.4.1",
     "react-native-screens": "3.5.0",
-    "react-native-vision-camera": "^2.9.4"
+    "react-native-vision-camera": "^2.15.2"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
Feel free to take this or leave this...

The example wasn't able to run until I updated the version of react-native-vision-camera. 

The install on yarn grabbed 2.9.4, which had the __scanCodes is undefined error.  Maybe this was because of the yarn.lockfile in /example, not sure.  Once I manually changed this version number in package.json, cleared cache and restarted the project the scanner worked properly.

